### PR TITLE
add inputfilter lib; use pkgconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/gptokeyb
+/inputfilter.so

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,28 @@
-CXX ?= gcc
-CCFLAGS = -W -Wall -std=c++11 `sdl2-config --cflags`
-INCLUDES = -I/usr/include/libevdev-1.0
+.PHONY: all clean
+
+CC ?= gcc
+CXX ?= g++
+CCFLAGS = -W -Wall -std=c++11 \
+	`pkg-config --cflags sdl2` \
+	`pkg-config --cflags libevdev`
 
 BINARY = gptokeyb
-LIBRARIES = -levdev `sdl2-config --libs`
+LIBRARIES = \
+	`pkg-config --libs sdl2` \
+	`pkg-config --libs libevdev`
 SOURCES = "gptokeyb.cpp"
 
-all:
+INPUTFILTER_LIB = inputfilter.so
+INPUTFILTER_SRC = inputfilter.c
+INPUTFILTER_CFGLAGS = -Wall -fPIC -shared
+
+all: $(BINARY) $(INPUTFILTER_LIB)
+
+$(BINARY):
 	$(CXX) $(CCFLAGS) $(INCLUDES) $(SOURCES) -o $(BINARY) $(LIBRARIES)
 
+$(INPUTFILTER_LIB):
+	$(CC) $(INPUTFILTER_CFGLAGS) $(INPUTFILTER_SRC) -o $(INPUTFILTER_LIB) -ldl
+
 clean:
-	rm -f $(BINARY)
+	rm -f $(BINARY) $(INPUTFILTER_LIB)

--- a/inputfilter.c
+++ b/inputfilter.c
@@ -1,0 +1,95 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <unistd.h>
+#include <linux/input.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdarg.h>
+
+static int allowed_vendor = -1;
+static int allowed_product = -1;
+static int initialized = 0;
+
+typedef int (*open_func_t)(const char*, int, ...);
+
+static open_func_t real_open = NULL;
+
+static void ensure_real_open() {
+    if (!real_open)
+        real_open = (open_func_t)dlsym(RTLD_NEXT, "open");
+}
+
+static void init_whitelist() {
+    if (initialized) return;
+    initialized = 1;
+    const char *env = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT");
+    if (!env) return;
+    // Expected form: 0xABCD/0x1234
+    unsigned vid, pid;
+    if (sscanf(env, "0x%x/0x%x", &vid, &pid) == 2) {
+        allowed_vendor = vid;
+        allowed_product = pid;
+    }
+}
+
+static int check_device(const char *path) {
+    if (allowed_vendor < 0 || allowed_product < 0) return 0; // No whitelist set, allow all
+    ensure_real_open();
+    int fd = real_open(path, O_RDONLY | O_NONBLOCK);
+    if (fd < 0) return 0; // Can't open for checking, allow
+    struct input_id id;
+    int ok = 0;
+    if (ioctl(fd, EVIOCGID, &id) == 0) {
+        if (id.vendor == allowed_vendor && id.product == allowed_product) {
+            ok = 1;
+        }
+    }
+    close(fd);
+    return ok;
+}
+
+
+int open(const char *pathname, int flags, ...) {
+    init_whitelist();
+    ensure_real_open();
+
+    // Only check regular open on /dev/input devices
+    if (strncmp(pathname, "/dev/input", 10) == 0) {
+        if (!check_device(pathname)) {
+            errno = EACCES;
+            return -1;
+        }
+    }
+
+    va_list args;
+    va_start(args, flags);
+    int mode = va_arg(args, int);
+    va_end(args);
+    return real_open(pathname, flags, mode);
+}
+
+// For open64
+int open64(const char *pathname, int flags, ...) {
+    init_whitelist();
+    static open_func_t real_open64 = NULL;
+    if (!real_open64) real_open64 = dlsym(RTLD_NEXT, "open64");
+
+    if (strncmp(pathname, "/dev/input", 10) == 0) {
+        if (!check_device(pathname)) {
+            errno = EACCES;
+            return -1;
+        }
+    }
+
+    va_list args;
+    va_start(args, flags);
+    int mode = va_arg(args, int);
+    va_end(args);
+    return real_open64(pathname, flags, mode);
+}


### PR DESCRIPTION
Here I add a simple inputfilter.so library to be used in combination with gptokeyb.  
It masks all input devices except one specified in SDL var, e.g.
```
SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT=0x045e/0x028e LD_PRELOAD=../inputfilter.so box64 hollow_knight.x86_64
```
thus preventing double inputs.

Bonux improvement: use pkg-config, making the Makefile ready for cross-compile (as a part of Rocknix)